### PR TITLE
Add flagship planet attribute condition.

### DIFF
--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3116,7 +3116,7 @@ void PlayerInfo::RegisterDerivedConditions()
 		if(!flagship || !flagship->GetPlanet())
 			return false;
 		string attribute = name.substr(strlen("flagship planet attribute: "));
-		return !!flagship->GetPlanet()->Attributes().count(attribute);
+		return flagship->GetPlanet()->Attributes().count(attribute);
 	};
 	flagshipPlanetAttributesProvider.SetGetFunction(flagshipPlanetAttributesFun);
 	flagshipPlanetAttributesProvider.SetHasFunction(flagshipPlanetAttributesFun);

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -3110,6 +3110,17 @@ void PlayerInfo::RegisterDerivedConditions()
 	flagshipPlanetProvider.SetHasFunction(flagshipPlanetFun);
 	flagshipPlanetProvider.SetGetFunction(flagshipPlanetFun);
 
+	auto &&flagshipPlanetAttributesProvider = conditions.GetProviderPrefixed("flagship planet attribute: ");
+	auto flagshipPlanetAttributesFun = [this](const string &name) -> bool
+	{
+		if(!flagship || !flagship->GetPlanet())
+			return false;
+		string attribute = name.substr(strlen("flagship planet attribute: "));
+		return !!flagship->GetPlanet()->Attributes().count(attribute);
+	};
+	flagshipPlanetAttributesProvider.SetGetFunction(flagshipPlanetAttributesFun);
+	flagshipPlanetAttributesProvider.SetHasFunction(flagshipPlanetAttributesFun);
+
 	// Read only exploration conditions.
 	auto &&visitedPlanetProvider = conditions.GetProviderPrefixed("visited planet: ");
 	auto visitedPlanetFun = [this](const string &name) -> bool

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -45,6 +45,7 @@ list(APPEND INTEGRATION_TESTS
 	integration/config/plugins/integration-tests/data/tests/tests_conditional_choice.txt
 	integration/config/plugins/integration-tests/data/tests/tests_disown.txt
 	integration/config/plugins/integration-tests/data/tests/tests_flagship_model_condition.txt
+	integration/config/plugins/integration-tests/data/tests/tests_flagship_planet_attribute.txt
 	integration/config/plugins/integration-tests/data/tests/tests_framework.txt
 	integration/config/plugins/integration-tests/data/tests/tests_illegal_atrocity.txt
 	integration/config/plugins/integration-tests/data/tests/tests_save_load.txt

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_flagship_planet_attribute.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_flagship_planet_attribute.txt
@@ -55,8 +55,6 @@ test-data "flagship planet attribute missions"
 			"Ruin: Landing: offered"
 		changes
 			planet Ruin
-				add shipyard "Remnant"
-				add outfitter "Remnant Core"
 				add attributes "Temperate Climate"
 
 

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_flagship_planet_attribute.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_flagship_planet_attribute.txt
@@ -59,53 +59,6 @@ test-data "flagship planet attribute missions"
 
 
 
-mission "%TEST%: FLAGSHIP PLANET ATTRIBUTE MISSION"
-	source "Ruin"
-	to offer
-		has "%TEST%: FLAGSHIP PLANET ATTRIBUTE MISSION OFFER"
-		has "flagship planet attribute: Temperate Climate"
-	on offer
-		conversation
-			`THIS IS A FLAGSHIP PLANET ATTRIBUTE MISSION YO!`
-				decline
-	on decline
-		set "succeed test"
-
-
-
-test "Trigger Flagship Planet Attribute Mission"
-	status partial
-	description "Launch, land, and go to the spaceport to trigger any potential missions in the shipyard."
-	sequence
-		call "Depart"
-		call "Land On Ruin helper"
-		input
-			key p
-
-
-
-test "End Flagship Planet Attribute Missions"
-	status partial
-	description "Just skip a mission by pressing return twice."
-	sequence
-		# Press accept (or decline, depending on if it is shown) and then skip the dialog once.
-		input
-			key "Return"
-		input
-			key "Return"
-
-
-test "Test Flagship Planet Attribute Mission"
-	status partial
-	description "Set a few conditions so they are displayed on errors, clarifying things up."
-	sequence
-		apply
-			# Test accepted. If not there it wasn't offered.
-			"test: succeed test" = "succeed test"
-			# if we launched
-			"test: flagship planet: Ruin" = "flagship planet: Ruin"
-
-
 test "Flagship Planet Attribute Mission Test"
 	status active
 	description "Test if a conversation option shows up when the given condition is set."
@@ -115,11 +68,3 @@ test "Flagship Planet Attribute Mission Test"
 		assert
 			"flagship planet attribute: Temperate Climate" == 1
 			"flagship planet attribute: ringworld" == 0
-		apply
-			"%TEST%: FLAGSHIP PLANET ATTRIBUTE MISSION OFFER" = 1
-		call "Trigger Flagship Planet Attribute Mission"
-		call "End Flagship Planet Attribute Missions"
-		call "Depart"
-		call "Test Shipyard And Outfitter Mission"
-		assert
-			"succeed test" == 1

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_flagship_planet_attribute.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_flagship_planet_attribute.txt
@@ -1,0 +1,124 @@
+test-data "flagship planet attribute missions"
+	category "savegame"
+	contents
+		pilot Bobbi Bughunter
+		date 16 11 3013
+		system "Terra Incognita"
+		planet Ruin
+		clearance
+		ship "Star Barge"
+			name "Buggy Barge"
+			sprite "ship/star barge"
+			attributes
+				category "Light Freighter"
+				cost 190000
+				mass 10
+				bunks 3
+				"cargo space" 50
+				drag 1
+				"engine capacity" 400
+				"fuel capacity" 300
+				"heat dissipation" 0.8
+				hull 1000
+				"outfit space" 1300
+				"required crew" 1
+				shields 600
+				"turret mounts" 1
+				"weapon capacity" 200
+				"thrust" 50
+				"turn" 1000
+			outfits
+				Hyperdrive
+				"nGVF-BB Fuel Cell"
+				"LP036a Battery Pack"
+			crew 1
+			fuel 300
+			shields 600
+			hull 1000
+			position 0 0
+			engine -9 38 1
+			engine 9 38 1
+			turret 0 -8
+			leak leak 60 50
+			explode "tiny explosion" 10
+			explode "small explosion" 10
+			system "Terra Incognita"
+			planet Ruin
+		account
+			credits 100000000
+			score 400
+			history
+		visited "Terra Incognita"
+		"visited planet" Ruin
+		conditions
+			# to skip the landing on ruin conversation
+			"Ruin: Landing: offered"
+		changes
+			planet Ruin
+				add shipyard "Remnant"
+				add outfitter "Remnant Core"
+				add attributes "Temperate Climate"
+
+
+
+mission "%TEST%: SHIPYARD MISSION"
+	source "Ruin"
+	to offer
+		has "%TEST%: FLAGSHIP PLANET ATTRIBUTE MISSION OFFER"
+		has "flagship planet attribute: Temperate Climate"
+	on offer
+		conversation
+			`THIS IS A FLAGSHIP PLANET ATTRIBUTE MISSION YO!`
+				decline
+	on decline
+		set "succeed test"
+
+
+
+test "Trigger Flagship Planet Attribute Mission"
+	status partial
+	description "Launch, land, and go to the spaceport to trigger any potential missions in the shipyard."
+	sequence
+		call "Depart"
+		call "Land On Ruin helper"
+		input
+			key p
+
+
+
+test "End Flagship Planet Attribute Missions"
+	status partial
+	description "Just skip a mission by pressing return twice."
+	sequence
+		# Press accept (or decline, depending on if it is shown) and then skip the dialog once.
+		input
+			key "Return"
+		input
+			key "Return"
+
+
+test "Test Flagship Planet Attribute Mission"
+	status partial
+	description "Set a few conditions so they are displayed on errors, clarifying things up."
+	sequence
+		apply
+			# Test accepted. If not there it wasn't offered.
+			"test: succeed test" = "succeed test"
+			# if we launched
+			"test: flagship planet: Ruin" = "flagship planet: Ruin"
+
+
+test "Flagship Planet Attribute Mission Test"
+	status active
+	description "Test if a conversation option shows up when the given condition is set."
+	sequence
+		inject "flagship planet attribute missions"
+		call "Load First Savegame"
+		apply
+			"%TEST%: FLAGSHIP PLANET ATTRIBUTE MISSION OFFER" = 1
+		call "Trigger Flagship Planet Attribute Mission"
+		call "End Flagship Planet Attribute Missions"
+		call "Depart"
+		call "Test Shipyard And Outfitter Mission"
+		assert
+			"succeed test" == 1

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_flagship_planet_attribute.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_flagship_planet_attribute.txt
@@ -61,7 +61,7 @@ test-data "flagship planet attribute missions"
 
 
 
-mission "%TEST%: SHIPYARD MISSION"
+mission "%TEST%: FLAGSHIP PLANET ATTRIBUTE MISSION"
 	source "Ruin"
 	to offer
 		has "%TEST%: FLAGSHIP PLANET ATTRIBUTE MISSION OFFER"

--- a/tests/integration/config/plugins/integration-tests/data/tests/tests_flagship_planet_attribute.txt
+++ b/tests/integration/config/plugins/integration-tests/data/tests/tests_flagship_planet_attribute.txt
@@ -112,6 +112,9 @@ test "Flagship Planet Attribute Mission Test"
 	sequence
 		inject "flagship planet attribute missions"
 		call "Load First Savegame"
+		assert
+			"flagship planet attribute: Temperate Climate" == 1
+			"flagship planet attribute: ringworld" == 0
 		apply
 			"%TEST%: FLAGSHIP PLANET ATTRIBUTE MISSION OFFER" = 1
 		call "Trigger Flagship Planet Attribute Mission"


### PR DESCRIPTION
This will allow conditions outside of LocationFilter based on planet attributes.

For https://github.com/endless-sky/endless-sky/issues/7656
## Feature Details
This will allow conditions outside of LocationFilter based on planet attributes.

## Usage Examples
```
has "flagship planet attribute: temperate climate"
```

### Testing Done & Automated Tests Added
Add an integration test 

## Performance Impact
Looking for a single membership in a set, so very low complexity.
