### PR TITLE
Add "to accept" ConditionSet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -467,6 +467,32 @@ jobs:
       run: ./utils/test_parse.sh ./"Contents/MacOS/${ES_BINARY}"
 
 
+  test_ubuntu-integration-parse:
+    needs: [build_ubuntu, changed]
+    if: ${{ needs.changed.outputs.game_code == 'true' || needs.changed.outputs.data == 'true' || needs.changed.outputs.integration_tests == 'true' }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        opengl: [desktop]
+        include:
+          - os: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install runtime dependencies
+      run: |
+        sudo rm /etc/apt/sources.list.d/* && sudo dpkg --clear-avail # Speed up installation and get rid of unwanted lists
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends libsdl2-2.0-0 libpng16-16 libjpeg-turbo8 libopenal1 libmad0 libglew2.2 libgl1 uuid-runtime libglvnd-dev
+    - name: Download game binary
+      uses: actions/download-artifact@v3
+      with:
+        name: binary-${{ matrix.os }}-${{ matrix.opengl }}
+    - name: Verify Executable
+      run: chmod +x endless-sky && ./endless-sky -v
+    - name: Parse Datafiles
+      run: ./utils/test_parse.sh ./endless-sky tests/integration/config
+
+
   test_memory-leaks-lite:
     needs: [test_ubuntu-parse, changed]
     if: needs.changed.outputs.game_code == 'true'

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -419,6 +419,7 @@
     {
       "name": "test",
       "hidden": true,
+      "configuration": "Debug",
       "output": {
         "shortProgress": true,
         "outputOnFailure": true
@@ -432,6 +433,7 @@
     {
       "name": "benchmark",
       "hidden": true,
+      "configuration": "Release",
       "output": {
         "verbosity": "verbose",
         "outputOnFailure": true

--- a/data/human/names.txt
+++ b/data/human/names.txt
@@ -4227,7 +4227,6 @@ phrase "bad outcomes"
 		"Blood"
 		"Poison"
 		"Blight"
-		"Fury"
 		"Misfortune"
 		"Damnation"
 		"Contagion"
@@ -4535,7 +4534,7 @@ phrase "pirate subphrase 2"
 	phrase
 		"pirate nouns" 110
 		"pirate nouns that work after bad outcomes" 27
-		"bad outcomes" 53
+		"bad outcomes" 52
 
 phrase "pirate subphrase 3"
 	phrase
@@ -4546,7 +4545,7 @@ phrase "pirate subphrase 3"
 		" "
 	phrase
 		"sinister names" 78
-		"bad outcomes" 53
+		"bad outcomes" 52
 
 phrase "pirate subphrase 4"
 	phrase
@@ -4556,7 +4555,7 @@ phrase "pirate subphrase 4"
 	phrase
 		"pirate nouns" 110
 		"pirate nouns that work after bad outcomes" 27
-		"bad outcomes" 53
+		"bad outcomes" 52
 	# When making a word ending in "s" possessive, only add an apostrophe.
 	replace
 		"s%'s" "s'"
@@ -4581,7 +4580,7 @@ phrase "pirate subphrase 6"
 
 phrase "pirate subphrase 7"
 	phrase
-		"bad outcomes" 53
+		"bad outcomes" 52
 		"pirate adjectives that work as titles" 65
 		"pirate adjectives that don't work as titles" 67
 	word
@@ -4593,7 +4592,7 @@ phrase "pirate subphrase 8"
 	phrase
 		"pirate nouns" 110
 		"pirate nouns that work after bad outcomes" 27
-		"bad outcomes" 53
+		"bad outcomes" 52
 
 phrase "pirate subphrase 9"
 	word

--- a/source/Mission.cpp
+++ b/source/Mission.cpp
@@ -231,6 +231,8 @@ void Mission::Load(const DataNode &node)
 				toComplete.Load(child);
 			else if(child.Token(1) == "fail")
 				toFail.Load(child);
+			else if(child.Token(1) == "accept")
+				toAccept.Load(child);
 			else
 				child.PrintTrace("Skipping unrecognized attribute:");
 		}
@@ -374,6 +376,15 @@ void Mission::Save(DataWriter &out, const string &tag) const
 			out.BeginChild();
 			{
 				toOffer.Save(out);
+			}
+			out.EndChild();
+		}
+		if(!toAccept.IsEmpty())
+		{
+			out.Write("to", "accept");
+			out.BeginChild();
+			{
+				toAccept.Save(out);
 			}
 			out.EndChild();
 		}
@@ -739,6 +750,10 @@ bool Mission::CanOffer(const PlayerInfo &player, const shared_ptr<Ship> &boardin
 
 bool Mission::CanAccept(const PlayerInfo &player) const
 {
+	const auto &playerConditions = player.Conditions();
+	if(!toAccept.Test(playerConditions))
+		return false;
+
 	auto it = actions.find(OFFER);
 	if(it != actions.end() && !it->second.CanBeDone(player))
 		return false;
@@ -1271,6 +1286,7 @@ Mission Mission::Instantiate(const PlayerInfo &player, const shared_ptr<Ship> &b
 	// Copy the conditions. The offer conditions must be copied too, because they
 	// may depend on a condition that other mission offers might change.
 	result.toOffer = toOffer;
+	result.toAccept = toAccept;
 	result.toComplete = toComplete;
 	result.toFail = toFail;
 

--- a/source/Mission.h
+++ b/source/Mission.h
@@ -224,6 +224,7 @@ private:
 	int64_t paymentApparent = 0;
 
 	ConditionSet toOffer;
+	ConditionSet toAccept;
 	ConditionSet toComplete;
 	ConditionSet toFail;
 

--- a/source/Test.cpp
+++ b/source/Test.cpp
@@ -364,6 +364,12 @@ void Test::Load(const DataNode &node)
 		}
 		else if(child.Token(0) == "sequence")
 			LoadSequence(child);
+		else if(child.Token(0) == "description")
+		{
+			// Provides a human friendly description of the test, but it is not used internally.
+		}
+		else
+			child.PrintTrace("Error: Skipping unrecognized attribute:");
 	}
 }
 

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -60,6 +60,11 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include <mmsystem.h>
 #endif
 
+namespace {
+	// The delay in frames when debugging the integration tests.
+	constexpr int UI_DELAY = 60;
+}
+
 using namespace std;
 
 void PrintHelp();
@@ -238,7 +243,7 @@ void GameLoop(PlayerInfo &player, const Conversation &conversation, const string
 	FrameTimer timer(frameRate);
 	bool isPaused = false;
 	bool isFastForward = false;
-	int testDebugUIDelay = 3 * 60;
+	int testDebugUIDelay = UI_DELAY;
 
 	// If fast forwarding, keep track of whether the current frame should be drawn.
 	int skipFrame = 0;
@@ -350,7 +355,7 @@ void GameLoop(PlayerInfo &player, const Conversation &conversation, const string
 				Command ignored;
 				runningTest->Step(testContext, player, ignored);
 				// Reset the visual delay.
-				testDebugUIDelay = 3 * 60;
+				testDebugUIDelay = UI_DELAY;
 			}
 			// Skip drawing 29 out of every 30 in-flight frames during testing to speedup testing (unless debug mode is set).
 			// We don't skip UI-frames to ensure we test the UI code more.

--- a/utils/test_parse.sh
+++ b/utils/test_parse.sh
@@ -14,6 +14,11 @@ elif [[ $OSTYPE == 'msys' ]] || [[ $OS == 'Windows_NT' ]] || [[ ! -z ${APPDATA:-
 else
   FILEDIR="$HOME/.local/share/endless-sky"
 fi
+# Check if a custom config location is specified.
+if [ "$2" ]; then
+  FILEDIR="$2"
+fi
+
 ERR_FILE="$FILEDIR/errors.txt"
 RUNTIME_ERRS="launch-errors.txt"
 # Remove any existing error files first.
@@ -22,7 +27,7 @@ if [ -f "$ERR_FILE" ]; then
 fi
 
 # Parse the game data files.
-if ! "$1" -p 2>"$RUNTIME_ERRS"; then
+if ! "$1" -p --config "$FILEDIR" 2>"$RUNTIME_ERRS"; then
   EXIT_CODE=$?
   echo "Error executing file/command '$1':"
   cat "$RUNTIME_ERRS"


### PR DESCRIPTION
I want to create a repeatable job based on @Hurleveur Unfettered Hai Duel mission framework.

The idea would be to create "Arena Duel" missions that would require the player to have no escorts, and possible be in a certain class of ship.

In order to do this the mission always need to be offered, but not acceptable unless the player meets some preconditions.

Thus the "to accept" conditions. It simply feeds into the existing Mission method CanAccept, just like "to offer" feeds into CanOffer.