### PR TITLE
First Rough Draft Of Crew Life Insurance Costs After Crew Deaths

### DIFF
--- a/source/AI.cpp
+++ b/source/AI.cpp
@@ -427,7 +427,7 @@ void AI::UpdateKeys(PlayerInfo &player, Command &activeCommands)
 
 
 
-void AI::UpdateEvents(const list<ShipEvent> &events)
+void AI::UpdateEvents(PlayerInfo &player, const list<ShipEvent> &events)
 {
 	for(const ShipEvent &event : events)
 	{
@@ -455,6 +455,22 @@ void AI::UpdateEvents(const list<ShipEvent> &events)
 				if(event.Type() & ShipEvent::PROVOKE)
 					newActions |= ShipEvent::PROVOKE;
 				event.TargetGovernment()->Offend(newActions, target->CrewValue());
+
+				if(event.Type() & ShipEvent::DESTROY)
+				{
+					player.HandleInflectedDestroyEvent(event.Target());
+				}
+			}
+		}
+		const auto &targetGovernment = event.TargetGovernment();
+		if(targetGovernment)
+		{
+			if(targetGovernment->IsPlayer())
+			{
+				if(event.Type() & ShipEvent::DESTROY)
+				{
+					player.HandleIncurredDestroyEvent(event.Target());
+				}
 			}
 		}
 	}

--- a/source/AI.h
+++ b/source/AI.h
@@ -61,7 +61,7 @@ template <class Type>
 	void UpdateKeys(PlayerInfo &player, Command &clickCommands);
 
 	// Allow the AI to track any events it is interested in.
-	void UpdateEvents(const std::list<ShipEvent> &events);
+	void UpdateEvents(PlayerInfo &player, const std::list<ShipEvent> &events);
 	// Reset the AI's memory of events.
 	void Clean();
 	// Clear ship orders. This should be done when the player lands on a planet,

--- a/source/Account.cpp
+++ b/source/Account.cpp
@@ -20,6 +20,7 @@ this program. If not, see <https://www.gnu.org/licenses/>.
 #include "text/Format.h"
 
 #include <algorithm>
+#include <cmath>
 #include <sstream>
 
 using namespace std;
@@ -362,7 +363,7 @@ void Account::DecayCrewLifeInsuranceCounter()
 
 
 
-double Account::CrewLifeInsuranceCounterMultiplier() const
+double Account::CrewLifeInsuranceSalariesMultiplier() const
 {
 	// The denominator could be configurable
 	return max(crewLifeInsuranceCounter / 100., 1.);
@@ -372,7 +373,7 @@ double Account::CrewLifeInsuranceCounterMultiplier() const
 
 int64_t Account::CalculateCrewLifeInsuranceCost(int64_t salaries) const
 {
-	return salaries * (CrewLifeInsuranceCounterMultiplier() - 1);
+	return salaries * (CrewLifeInsuranceSalariesMultiplier() - 1);
 }
 
 

--- a/source/Account.cpp
+++ b/source/Account.cpp
@@ -347,7 +347,7 @@ void Account::AddFine(int64_t amount)
 
 
 
-void Account::AddCrewLifeInsuranceCounter(int64_t deaths)
+void Account::AddCrewLifeInsuranceCounter(int deaths)
 {
 	// The Max could be configurable
 	crewLifeInsuranceCounter = min(crewLifeInsuranceCounter + deaths, 1000);

--- a/source/Account.cpp
+++ b/source/Account.cpp
@@ -41,6 +41,7 @@ void Account::Load(const DataNode &node, bool clearFirst)
 		credits = 0;
 		salariesOwed = 0;
 		maintenanceDue = 0;
+		crewLifeInsuranceOwed = 0;
 		creditScore = 400;
 		mortgages.clear();
 		history.clear();
@@ -54,6 +55,8 @@ void Account::Load(const DataNode &node, bool clearFirst)
 			salariesOwed = child.Value(1);
 		else if(child.Token(0) == "maintenance" && child.Size() >= 2)
 			maintenanceDue = child.Value(1);
+		else if(child.Token(0) == "crew life insurance")
+			crewLifeInsuranceOwed = child.Value(1);
 		else if(child.Token(0) == "score" && child.Size() >= 2)
 			creditScore = child.Value(1);
 		else if(child.Token(0) == "mortgage")
@@ -79,6 +82,8 @@ void Account::Save(DataWriter &out) const
 			out.Write("salaries", salariesOwed);
 		if(maintenanceDue)
 			out.Write("maintenance", maintenanceDue);
+		if(crewLifeInsuranceOwed)
+			out.Write("crew life insurance", crewLifeInsuranceOwed);
 		out.Write("score", creditScore);
 
 		out.Write("history");
@@ -140,7 +145,8 @@ string Account::Step(int64_t assets, int64_t salaries, int64_t maintenance)
 	ostringstream out;
 
 	// Keep track of what payments were made and whether any could not be made.
-	salariesOwed += salaries + CalculateCrewLifeInsuranceCost(salaries);
+	salariesOwed += salaries;
+	crewLifeInsuranceOwed += CalculateCrewLifeInsurance(salaries);
 	maintenanceDue += maintenance;
 	bool missedPayment = false;
 
@@ -162,6 +168,27 @@ string Account::Step(int64_t assets, int64_t salaries, int64_t maintenance)
 		{
 			credits -= salariesOwed;
 			salariesOwed = 0;
+		}
+	}
+
+	// Next is crew life insurance.
+	int64_t crewLifeInsurancePaid = crewLifeInsuranceOwed;
+	if(crewLifeInsuranceOwed)
+	{
+		if(crewLifeInsuranceOwed > credits)
+		{
+			// If you can't pay the full salary amount, still pay some of it and
+			// remember how much back wages you owe to your crew.
+			crewLifeInsurancePaid = max<int64_t>(credits, 0);
+			crewLifeInsuranceOwed -= crewLifeInsurancePaid;
+			credits -= crewLifeInsurancePaid;
+			missedPayment = true;
+			out << "You could not pay all your crew life insurance salaries.";
+		}
+		else
+		{
+			credits -= crewLifeInsuranceOwed;
+			crewLifeInsuranceOwed = 0;
 		}
 	}
 
@@ -225,7 +252,7 @@ string Account::Step(int64_t assets, int64_t salaries, int64_t maintenance)
 	// Keep track of your net worth over the last HISTORY days.
 	if(history.size() > HISTORY)
 		history.erase(history.begin());
-	history.push_back(credits + assets - salariesOwed - maintenanceDue);
+	history.push_back(credits + assets - salariesOwed - crewLifeInsuranceOwed - maintenanceDue);
 
 	// If you failed to pay any debt, your credit score drops. Otherwise, even
 	// if you have no debts, it increases. (Because, having no debts at all
@@ -233,7 +260,7 @@ string Account::Step(int64_t assets, int64_t salaries, int64_t maintenance)
 	creditScore = max(200, min(800, creditScore + (missedPayment ? -5 : 1)));
 
 	// If you didn't make any payments, no need to continue further.
-	if(!(salariesPaid + maintenancePaid + mortgagesPaid + finesPaid))
+	if(!(salariesPaid + crewLifeInsurancePaid + maintenancePaid + mortgagesPaid + finesPaid))
 		return out.str();
 	else if(missedPayment)
 		out << " ";
@@ -248,6 +275,8 @@ string Account::Step(int64_t assets, int64_t salaries, int64_t maintenance)
 	map<string, int64_t> typesPaid;
 	if(salariesPaid)
 		typesPaid["crew salaries"] = salariesPaid;
+	if(crewLifeInsurancePaid)
+		typesPaid["crew life insurance"] = crewLifeInsurancePaid;
 	if(maintenancePaid)
 		typesPaid["maintenance"] = maintenancePaid;
 	if(mortgagesPaid)
@@ -271,6 +300,9 @@ string Account::Step(int64_t assets, int64_t salaries, int64_t maintenance)
 	{
 		if(salariesPaid)
 			out << creditString(salariesPaid) << " in crew salaries"
+				<< ((crewLifeInsurancePaid || mortgagesPaid || finesPaid || maintenancePaid) ? " and " : ".");
+		if(crewLifeInsurancePaid)
+			out << creditString(crewLifeInsurancePaid) << " in crew life insurance"
 				<< ((mortgagesPaid || finesPaid || maintenancePaid) ? " and " : ".");
 		if(maintenancePaid)
 			out << creditString(maintenancePaid) << "  in maintenance"
@@ -346,6 +378,21 @@ void Account::AddFine(int64_t amount)
 }
 
 
+int64_t Account::CrewLifeInsuranceOwed() const
+{
+	return crewLifeInsuranceOwed;
+}
+
+
+
+void Account::PayCrewLifeInsurance(int64_t amount)
+{
+	amount = min(min(amount, crewLifeInsuranceOwed), credits);
+	credits -= amount;
+	crewLifeInsuranceOwed -= amount;
+}
+
+
 
 void Account::AddCrewLifeInsuranceCounter(int deaths)
 {
@@ -371,7 +418,7 @@ double Account::CrewLifeInsuranceSalariesMultiplier() const
 
 
 
-int64_t Account::CalculateCrewLifeInsuranceCost(int64_t salaries) const
+int64_t Account::CalculateCrewLifeInsurance(int64_t salaries) const
 {
 	return salaries * (CrewLifeInsuranceSalariesMultiplier() - 1);
 }

--- a/source/Account.cpp
+++ b/source/Account.cpp
@@ -346,7 +346,7 @@ void Account::AddFine(int64_t amount)
 
 
 
-void AddCrewLifeInsuranceCounter(int64_t deaths)
+void Account::AddCrewLifeInsuranceCounter(int64_t deaths)
 {
 	// The Max could be configurable
 	crewLifeInsuranceCounter = min(crewLifeInsuranceCounter + deaths, 1000);
@@ -354,7 +354,7 @@ void AddCrewLifeInsuranceCounter(int64_t deaths)
 
 
 
-void DecayCrewLifeInsuranceCounter()
+void Account::DecayCrewLifeInsuranceCounter()
 {
 	// The decay could be configurable
 	crewLifeInsuranceCounter = floor(crewLifeInsuranceCounter * 0.95);
@@ -362,7 +362,7 @@ void DecayCrewLifeInsuranceCounter()
 
 
 
-double CrewLifeInsuranceCounterMultiplier() const
+double Account::CrewLifeInsuranceCounterMultiplier() const
 {
 	// The denominator could be configurable
 	return max(crewLifeInsuranceCounter / 100., 1.);
@@ -370,9 +370,9 @@ double CrewLifeInsuranceCounterMultiplier() const
 
 
 
-int64_t CalculateCrewLifeInsuranceCost(int64_t salaries) const
+int64_t Account::CalculateCrewLifeInsuranceCost(int64_t salaries) const
 {
-	return salaries * (CrewLifeInsuranceCounterMultiplier - 1)
+	return salaries * (CrewLifeInsuranceCounterMultiplier() - 1);
 }
 
 

--- a/source/Account.h
+++ b/source/Account.h
@@ -57,7 +57,7 @@ public:
 	void AddCrewLifeInsuranceCounter(int deaths);
 	void DecayCrewLifeInsuranceCounter();
 	double CrewLifeInsuranceSalariesMultiplier() const;
-	int64_t CalculateCrewLifeInsuranceCost(int64_t salaries) const;
+	int64_t CalculateCrewLifeInsurance(int64_t salaries) const;
 	int64_t Prequalify() const;
 	// Assets:
 	int64_t NetWorth() const;
@@ -78,6 +78,7 @@ private:
 	// than being ignored.
 	int64_t salariesOwed = 0;
 	int64_t maintenanceDue = 0;
+	int64_t crewLifeInsuranceOwed = 0;
 	// Your credit score determines the interest rate on your mortgages.
 	int creditScore = 400;
 	int crewLifeInsuranceCounter = 0;

--- a/source/Account.h
+++ b/source/Account.h
@@ -54,7 +54,7 @@ public:
 	const std::vector<Mortgage> &Mortgages() const;
 	void AddMortgage(int64_t principal);
 	void AddFine(int64_t amount);
-	void AddCrewLifeInsuranceCounter(int64_t deaths);
+	void AddCrewLifeInsuranceCounter(int deaths);
 	void DecayCrewLifeInsuranceCounter();
 	double CrewLifeInsuranceSalariesMultiplier() const;
 	int64_t CalculateCrewLifeInsuranceCost(int64_t salaries) const;
@@ -80,7 +80,7 @@ private:
 	int64_t maintenanceDue = 0;
 	// Your credit score determines the interest rate on your mortgages.
 	int creditScore = 400;
-	int64_t crewLifeInsuranceCounter = 0;
+	int crewLifeInsuranceCounter = 0;
 
 	std::vector<Mortgage> mortgages;
 

--- a/source/Account.h
+++ b/source/Account.h
@@ -54,6 +54,10 @@ public:
 	const std::vector<Mortgage> &Mortgages() const;
 	void AddMortgage(int64_t principal);
 	void AddFine(int64_t amount);
+	void AddCrewLifeInsuranceCounter(int64_t deaths);
+	void DecayCrewLifeInsuranceCounter();
+	double CrewLifeInsuranceSalariesMultiplier() const;
+	int64_t CalculateCrewLifeInsuranceCost(int64_t salaries) const;
 	int64_t Prequalify() const;
 	// Assets:
 	int64_t NetWorth() const;
@@ -76,6 +80,7 @@ private:
 	int64_t maintenanceDue = 0;
 	// Your credit score determines the interest rate on your mortgages.
 	int creditScore = 400;
+	int64_t crewLifeInsuranceCounter = 0;
 
 	std::vector<Mortgage> mortgages;
 

--- a/source/BankPanel.cpp
+++ b/source/BankPanel.cpp
@@ -48,7 +48,7 @@ namespace {
 	const int FIRST_Y = 78;
 
 	// Maximum number of rows of mortages, etc. to draw.
-	const int MAX_ROWS = 8;
+	const int MAX_ROWS = 9;
 }
 
 
@@ -109,6 +109,8 @@ void BankPanel::Draw()
 	// Check if salaries need to be drawn.
 	int64_t salaries = player.Salaries();
 	int64_t salariesOwed = player.Accounts().SalariesOwed();
+	int64_t crewLifeInsurance = player.Accounts().CalculateCrewLifeInsurance(salaries);
+	int64_t CrewLifeInsuranceOwed = player.Accounts().CrewLifeInsuranceOwed();
 	int64_t income[2] = {0, 0};
 	static const string prefix[2] = {"salary: ", "tribute: "};
 	for(int i = 0; i < 2; ++i)
@@ -122,7 +124,8 @@ void BankPanel::Draw()
 	int64_t maintenanceDue = player.Accounts().MaintenanceDue();
 	// Figure out how many rows of the display are for mortgages, and also check
 	// whether multiple mortgages have to be combined into the last row.
-	mortgageRows = MAX_ROWS - (salaries != 0 || salariesOwed != 0) - (b.maintenanceCosts != 0 || maintenanceDue != 0)
+	mortgageRows = MAX_ROWS - (salaries != 0 || salariesOwed != 0) - (crewLifeInsurance != 0 || CrewLifeInsuranceOwed != 0)
+		- (b.maintenanceCosts != 0 || maintenanceDue != 0)
 		- (b.assetsReturns != 0 || income[0] != 0 || income[1] != 0);
 	int mortgageCount = player.Accounts().Mortgages().size();
 	mergedMortgages = (mortgageCount > mortgageRows);
@@ -192,6 +195,24 @@ void BankPanel::Draw()
 		else
 			table.Advance(3);
 		table.Draw(Format::Credits(salaries));
+		table.Advance();
+	}
+	if(crewLifeInsurance)
+	{
+		// Include crew life insurance ost in the total daily payment.
+		totalPayment += crewLifeInsurance;
+
+		table.Draw("Crew Life Insurance");
+		// Check whether the player owes back salaries.
+		if(CrewLifeInsuranceOwed)
+		{
+			table.Draw(Format::Credits(CrewLifeInsuranceOwed));
+			table.Draw("(overdue)");
+			table.Advance(1);
+		}
+		else
+			table.Advance(3);
+		table.Draw(Format::Credits(crewLifeInsurance));
 		table.Advance();
 	}
 	// Draw the maintenance costs, if necessary.
@@ -303,6 +324,7 @@ bool BankPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command, boo
 				++i;
 		}
 		player.Accounts().PaySalaries(player.Accounts().SalariesOwed());
+		player.Accounts().PayCrewLifeInsurance(player.Accounts().CrewLifeInsuranceOwed());
 		player.Accounts().PayMaintenance(player.Accounts().MaintenanceDue());
 		qualify = player.Accounts().Prequalify();
 	}

--- a/source/BoardingPanel.cpp
+++ b/source/BoardingPanel.cpp
@@ -350,9 +350,7 @@ bool BoardingPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command,
 					player.HandleIncurredCrewCasualties(-1);
 				}
 				else
-				{
 					victim->AddCrew(-1);
-				}
 			}
 
 			// Report how many casualties each side suffered.

--- a/source/BoardingPanel.cpp
+++ b/source/BoardingPanel.cpp
@@ -345,10 +345,14 @@ bool BoardingPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command,
 					break;
 
 				if(Random::Real() * total >= yourPower)
+				{
 					you->AddCrew(-1);
 					player.HandleIncurredCrewCasualties(-1);
+				}
 				else
+				{
 					victim->AddCrew(-1);
+				}
 			}
 
 			// Report how many casualties each side suffered.

--- a/source/BoardingPanel.cpp
+++ b/source/BoardingPanel.cpp
@@ -346,6 +346,7 @@ bool BoardingPanel::KeyDown(SDL_Keycode key, Uint16 mod, const Command &command,
 
 				if(Random::Real() * total >= yourPower)
 					you->AddCrew(-1);
+					player.HandleIncurredCrewCasualties(-1);
 				else
 					victim->AddCrew(-1);
 			}

--- a/source/Engine.cpp
+++ b/source/Engine.cpp
@@ -482,7 +482,7 @@ void Engine::Step(bool isActive)
 		else if(jumpCount > 0)
 			--jumpCount;
 	}
-	ai.UpdateEvents(events);
+	ai.UpdateEvents(player, events);
 	if(isActive)
 	{
 		HandleKeyboardInputs();

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2543,7 +2543,7 @@ set<string> &PlayerInfo::Collapsed(const string &name)
 
 
 
-void HandleIncurredDestroyEvent(const std::shared_ptr<Ship> &ship)
+void PlayerInfo::HandleIncurredDestroyEvent(const std::shared_ptr<Ship> &ship)
 {
 	incurredShipLosses++;
 	incurredCrewCasualties += ship ? ship->Crew() : 0;
@@ -2551,13 +2551,13 @@ void HandleIncurredDestroyEvent(const std::shared_ptr<Ship> &ship)
 
 
 
-void HandleInflectedDestroyEvent(const std::shared_ptr<Ship> &ship)
+void PlayerInfo::HandleInflectedDestroyEvent(const std::shared_ptr<Ship> &ship)
 {
 	inflictedShipLosses++;
 	inflictedCrewCasualties += ship ? ship->Crew() : 0;
 }
 
-void HandleIncurredCrewCasualties(int deaths)
+void PlayerInfo::HandleIncurredCrewCasualties(int deaths)
 {
 	incurredCrewCasualties += deaths;
 }

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -2546,7 +2546,8 @@ set<string> &PlayerInfo::Collapsed(const string &name)
 void PlayerInfo::HandleIncurredDestroyEvent(const std::shared_ptr<Ship> &ship)
 {
 	incurredShipLosses++;
-	incurredCrewCasualties += ship ? ship->Crew() : 0;
+	int deaths = ship ? ship->Crew() : 0;
+	HandleIncurredCrewCasualties(deaths);
 }
 
 
@@ -2560,6 +2561,7 @@ void PlayerInfo::HandleInflectedDestroyEvent(const std::shared_ptr<Ship> &ship)
 void PlayerInfo::HandleIncurredCrewCasualties(int deaths)
 {
 	incurredCrewCasualties += deaths;
+	accounts.AddCrewLifeInsuranceCounter(deaths);
 }
 
 

--- a/source/PlayerInfo.cpp
+++ b/source/PlayerInfo.cpp
@@ -345,6 +345,14 @@ void PlayerInfo::Load(const string &path)
 		}
 		else if(child.Token(0) == "start")
 			startData.Load(child);
+		else if(child.Token(0) == "incurred crew casualties" && child.Size() >= 2)
+			incurredCrewCasualties = child.Value(1);
+		else if(child.Token(0) == "incurred ship losses" && child.Size() >= 2)
+			incurredShipLosses = child.Value(1);
+		else if(child.Token(0) == "inflicted crew casualties" && child.Size() >= 2)
+			inflictedCrewCasualties = child.Value(1);
+		else if(child.Token(0) == "inflicted ship losses" && child.Size() >= 2)
+			inflictedShipLosses = child.Value(1);
 	}
 	// Modify the game data with any changes that were loaded from this file.
 	ApplyChanges();
@@ -2535,6 +2543,27 @@ set<string> &PlayerInfo::Collapsed(const string &name)
 
 
 
+void HandleIncurredDestroyEvent(const std::shared_ptr<Ship> &ship)
+{
+	incurredShipLosses++;
+	incurredCrewCasualties += ship ? ship->Crew() : 0;
+}
+
+
+
+void HandleInflectedDestroyEvent(const std::shared_ptr<Ship> &ship)
+{
+	inflictedShipLosses++;
+	inflictedCrewCasualties += ship ? ship->Crew() : 0;
+}
+
+void HandleIncurredCrewCasualties(int deaths)
+{
+	incurredCrewCasualties += deaths;
+}
+
+
+
 // Apply any "changes" saved in this player info to the global game state.
 void PlayerInfo::ApplyChanges()
 {
@@ -3841,6 +3870,11 @@ void PlayerInfo::Save(const string &path) const
 	out.Write();
 	out.WriteComment("How you began:");
 	startData.Save(out);
+
+	out.Write("incurred crew casualties", incurredCrewCasualties);
+	out.Write("incurred ship losses", incurredShipLosses);
+	out.Write("inflicted crew casualties", inflictedCrewCasualties);
+	out.Write("inflicted ship losses", inflictedShipLosses);
 
 	// Write plugins to player's save file for debugging.
 	if(!GameData::PluginAboutText().empty())

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -291,7 +291,7 @@ public:
 	void SetMapZoom(int level);
 	// Get the set of collapsed categories for the named panel.
 	std::set<std::string> &Collapsed(const std::string &name);
-	void HandleIncurredDestroyEvent(const std::shared_ptr<Ship> &ship);
+w	void HandleIncurredDestroyEvent(const std::shared_ptr<Ship> &ship);
 	void HandleInflectedDestroyEvent(const std::shared_ptr<Ship> &ship);
 	void HandleIncurredCrewCasualties(int deaths);
 

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -291,7 +291,7 @@ public:
 	void SetMapZoom(int level);
 	// Get the set of collapsed categories for the named panel.
 	std::set<std::string> &Collapsed(const std::string &name);
-w	void HandleIncurredDestroyEvent(const std::shared_ptr<Ship> &ship);
+	void HandleIncurredDestroyEvent(const std::shared_ptr<Ship> &ship);
 	void HandleInflectedDestroyEvent(const std::shared_ptr<Ship> &ship);
 	void HandleIncurredCrewCasualties(int deaths);
 

--- a/source/PlayerInfo.h
+++ b/source/PlayerInfo.h
@@ -291,6 +291,9 @@ public:
 	void SetMapZoom(int level);
 	// Get the set of collapsed categories for the named panel.
 	std::set<std::string> &Collapsed(const std::string &name);
+	void HandleIncurredDestroyEvent(const std::shared_ptr<Ship> &ship);
+	void HandleInflectedDestroyEvent(const std::shared_ptr<Ship> &ship);
+	void HandleIncurredCrewCasualties(int deaths);
 
 
 private:
@@ -407,6 +410,13 @@ private:
 
 	// Basic information about the player's starting scenario.
 	CoreStartData startData;
+
+	// Player Stats
+	int64_t incurredCrewCasualties = 0;
+	int64_t incurredShipLosses = 0;
+
+	int64_t inflictedCrewCasualties = 0;
+	int64_t inflictedShipLosses = 0;
 };
 
 


### PR DESCRIPTION
TODO: UI Changes in the bank and daily messages

Every crew death causes a “life insurance” counter to be incremented on the player account. The “life insurance”counter also decays, don’t know the exact rate but something like 5% per day.

From a value of 0 to 100 the counter does nothing. But after 100 to 1000 the cost of crew salaries scales by a factor of ( “life insurance”/ 100).

So at 200 “life insurance” you would pay your normal crew salary plus the salary once over again in “life insurance plan costs”. At the cap of 1,000 you would pay your crew salary plus your crew salary 9 times over as “life insurance plan costs”.
